### PR TITLE
fix: update regex for detect merge commits after dropping bors

### DIFF
--- a/src/bin/milestone.rs
+++ b/src/bin/milestone.rs
@@ -184,8 +184,9 @@ fn doit() -> Result<()> {
         .skip(1)
         .next()
         .ok_or_else(|| format_err!("expected path to rust repo as first argument"))?;
-    let token = env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN must be set");
-    let auth = base64::encode(format!("ehuss:{token}"));
+    let token =
+        env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN must be set in <username>:<token> format");
+    let auth = base64::encode(token);
     let rust_repo = Path::new(&rust_repo);
     fetch(&rust_repo)?;
     let milestones = determine_milestones(&auth, &rust_repo)?;


### PR DESCRIPTION
c8f2869a7c2484f22753e726e3c3edc4e647e6a8 is probably more important. It updates how we detect merge PRs for updating Cargo milestone after migrating away from bors. The regex is a bit brittle, though I expect it should be fine for short term.

